### PR TITLE
Skip jmeter integration test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,5 +62,7 @@ jobs:
           kind load docker-image hellofresh/kangal-ghz:local
       
       - name: Kangal Integration Tests
+        env:
+          SKIP_JMETER_INTEGRATION_TEST: "1"
         run: |
           ./ci/integration-tests.sh


### PR DESCRIPTION
This PR enables the flag to skip jmeter integration test.