### PR TITLE
change the file path for archived file

### DIFF
--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -33,10 +33,3 @@ if [ "$REQUEST_COUNT" -eq "0" ]; then
   echo "Expected dummy grpc server to receive >0 request, but found 0. Test failed."
   exit 1
 fi
-
-sleep 15
-kubectl get loadtest
-
-LOADTEST=$(kubectl get loadtest | grep Ghz | cut -d " " -f1)
-
-curl -X GET "http://${KANGAL_PROXY_ADDRESS}/load-test/${LOADTEST}/logs"

--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -34,10 +34,9 @@ if [ "$REQUEST_COUNT" -eq "0" ]; then
   exit 1
 fi
 
+sleep 15
 kubectl get loadtest
 
-LOADTEST=$(kubectl get loadtest | awk '{print $1;}')
+LOADTEST=$(kubectl get loadtest | grep Ghz | cut -d " " -f1)
 
-curl -X GET "http://${KANGAL_PROXY_ADDRESS}/load-test/${LOADTEST}/logs" \
---header 'Content-Type: application/json'
-
+curl -X GET "http://${KANGAL_PROXY_ADDRESS}/load-test/${LOADTEST}/logs"

--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -33,3 +33,11 @@ if [ "$REQUEST_COUNT" -eq "0" ]; then
   echo "Expected dummy grpc server to receive >0 request, but found 0. Test failed."
   exit 1
 fi
+
+kubectl get loadtest
+
+LOADTEST=$(kubectl get loadtest | awk '{print $1;}')
+
+curl -X GET "http://${KANGAL_PROXY_ADDRESS}/load-test/${LOADTEST}/logs" \
+--header 'Content-Type: application/json'
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,6 @@ set -e
 # Upload Results
 if [ -n "${REPORT_PRESIGNED_URL}" ]; then
   echo "=== Saving report to Object storage ==="
-  tar -C /results -cf results.tar .
+  tar -zcf results.tar ../results
   curl -X PUT -H "Content-Type: application/x-tar" -T results.tar -L "${REPORT_PRESIGNED_URL}"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,5 @@ set -e
 # Upload Results
 if [ -n "${REPORT_PRESIGNED_URL}" ]; then
   echo "=== Saving report to Object storage ==="
-  tar -cf results.tar ../results.html
-  curl -X PUT -H "Content-Type: application/x-tar" -T results.tar -L "${REPORT_PRESIGNED_URL}"
+  curl -X PUT -H "Content-Type: application/x-tar" -T ../results.html -L "${REPORT_PRESIGNED_URL}"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,6 @@ set -e
 # Upload Results
 if [ -n "${REPORT_PRESIGNED_URL}" ]; then
   echo "=== Saving report to Object storage ==="
-  tar -zcf results.tar ../results
+  tar -cf results.tar ../results.html
   curl -X PUT -H "Content-Type: application/x-tar" -T results.tar -L "${REPORT_PRESIGNED_URL}"
 fi


### PR DESCRIPTION
This PR updated the file path for compressed file in tar command. It should help with the error 
```
tar: /results: Cannot open: Not a directory
tar: Error is not recoverable: exiting now
```