### PR TITLE
Feat: Change release to GHCR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,13 @@ on:
     types:
       - created
 
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+
 jobs:
   build_docker:
     name: Build docker image release
@@ -18,11 +25,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
         with:
-          username: hellofreshtech
-          password: ${{ secrets.DOCKER_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker base image
         uses: docker/build-push-action@v2
@@ -31,5 +39,5 @@ jobs:
           build-args: |
             GHZ_VERSION=${{env.GHZ_VERSION}}
           tags: |
-            hellofresh/kangal-ghz:${{env.GHZ_VERSION}}
-            hellofresh/kangal-ghz:latest
+            ${{env.REGISTRY}}/hellofresh/kangal-ghz:${{env.GHZ_VERSION}}
+            ${{env.REGISTRY}}/hellofresh/kangal-ghz:latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,10 +20,10 @@ jobs:
       GHZ_VERSION: "0.95.0"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -33,7 +33,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker base image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           push: true
           build-args: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,10 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Lint
-        uses: github/super-linter@v4
+        uses: github/super-linter@v5
         env:
           FILTER_REGEX_EXCLUDE: .*testdata/.*
           VALIDATE_ALL_CODEBASE: false
@@ -30,16 +32,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Build Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           tags: hellofresh/kangal-ghz:local
           push: false
 
       - name: Build dummy gRPC server Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           tags: greeter_server:local
           file: ./testdata/Dockerfile
@@ -47,12 +49,12 @@ jobs:
           push: false
 
       - name: Setup Kind
-        uses: engineerd/setup-kind@v0.5.0
+        uses: engineerd/setup-kind@v0.6.2
         with:
           version: "v0.11.1"
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v4
         with:
           version: v3.4.0
 
@@ -60,7 +62,7 @@ jobs:
         run: |
           kind load docker-image greeter_server:local
           kind load docker-image hellofresh/kangal-ghz:local
-      
+
       - name: Kangal Integration Tests
         run: |
           ./ci/integration-tests.sh

--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ A simple [`ghz`] docker image specifically configured for [Kangal].
 
 > [!WARNING]
 > Kangal's upload to DockerHub has been removed
-> We apologize for the disruption, but you can get the image from `ghcr.io/hellofresh/kangal-ghz` from January 31st onwards.
+> We apologize for the disruption, but you can get the image from `ghcr.io/hellofresh/kangal-ghz` from January 31st 2026 onwards.
 >
 > The registry in DockerHub will not be available from February-onwards

--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@ A simple [`ghz`] docker image specifically configured for [Kangal].
 
 [Kangal]: https://github.com/hellofresh/kangal/
 [`ghz`]: https://github.com/bojand/ghz/
+
+> [!WARNING]
+> Kangal's upload to DockerHub has been removed
+> We apologize for the disruption, but you can get the image from `ghcr.io/hellofresh/kangal-ghz` from January 31st onwards.
+>
+> The registry in DockerHub will not be available from February-onwards


### PR DESCRIPTION
Dockerhub won't be accessible in February, so we must start pushing here instead