### PR TITLE
Use publish trigger

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Build and release docker images
 on:
   release:
     types:
-      - created
+      - published
 
 permissions:
   contents: read


### PR DESCRIPTION
https://github.com/hellofresh/kangal-ghz/actions/workflows/release.yaml wasn't triggered after publishing 0.96.0 
This should fix it.